### PR TITLE
Add filtering on recipe search

### DIFF
--- a/src/controllers/recipes_controller.js
+++ b/src/controllers/recipes_controller.js
@@ -12,8 +12,8 @@ module.exports.findAllRecipes = (req, res) => {
     });
 };
 
-module.exports.searchRecipes = ({query: {keyword = null}}, res) => {
-    recipesModel.search(keyword, (err, result) => {
+module.exports.searchRecipes = ({body: {query = null}}, res) => {
+    recipesModel.search(query, (err, result) => {
         if (err) {
             console.log(err);
         }

--- a/src/models/recipes_model.js
+++ b/src/models/recipes_model.js
@@ -36,12 +36,8 @@ module.exports.selectRecipeById = (id, callback) => {
     ], callback);
 };
 
-const searchRecipesCollection = (client, collection, keyword, next) => {
-    collection.find({
-        $text: {
-            $search: keyword
-        }
-    }).toArray((err, items) => {
+const searchRecipesCollection = (client, collection, query, next) => {
+    collection.find(query).toArray((err, items) => {
         client.close(() => next(err, items));
     });
 };
@@ -63,10 +59,10 @@ const createIndex = (client, collection, next) => {
     }, next);
 };
 
-module.exports.search = (keyword, callback) => {
+module.exports.search = (query, callback) => {
     async.waterfall([
         connect,
-        (client, collection, next) => searchRecipesCollection(client, collection, keyword, next)
+        (client, collection, next) => searchRecipesCollection(client, collection, query, next)
     ], callback);
 };
 

--- a/src/routes/recipes_routes.js
+++ b/src/routes/recipes_routes.js
@@ -7,7 +7,7 @@ if (env !== "testing") {
 }
 
 app.get("/", recipesController.findAllRecipes);
-app.get("/search", recipesController.searchRecipes);
+app.post("/search", recipesController.searchRecipes);
 app.get("/id/:recipeId", recipesController.selectRecipeById);
 app.get("/python_test", recipesController.callPythonScriptTest);
 app.get("/process_json", recipesController.processRecipesJson);

--- a/test/controllers/recipe_controller_test.js
+++ b/test/controllers/recipe_controller_test.js
@@ -29,7 +29,7 @@ describe("Endpoints exists for recipes", () => {
     });
 
     describe("/POST search/filter recipes", () => {
-        it("the search recipe should get recipes", (done) => {
+        it("should return a list of recipes with a keyword search", (done) => {
             chai.request(recipeRoutes).
                 post("/recipes/search").
                 set("content-type", "application/json").
@@ -47,6 +47,31 @@ describe("Endpoints exists for recipes", () => {
                     done();
                 });
         });
+
+        it("should return a list of recipes with a keyword and caloric filter", (done) => {
+            chai.request(recipeRoutes).
+                post("/recipes/search").
+                set("content-type", "application/json").
+                send({
+                    "query": {
+                        "$text": {
+                            "$search": "pork"
+                        }, 
+                        "nutrition.calories.amount": {
+                            "$lt": 500
+                        }
+                    }
+                }).
+                end((err, res) => {
+                    should.not.exist(err);
+                    res.should.have.status(200);
+                    res.body.should.be.a("array");
+                    for (let recipe of res.body) {
+                        expect(recipe.nutrition.calories.amount).to.be.below(500)
+                    }
+                    done();
+                });
+        });
     });
 
     describe("/GET recipes by Id", () => {
@@ -58,7 +83,6 @@ describe("Endpoints exists for recipes", () => {
                     res.should.have.status(200);
                     expect(res.body).to.not.be.empty;
                     expect(res.body.id).to.equal(25449);
-                    console.log(res.body)
                     done();
                 });
         });

--- a/test/controllers/recipe_controller_test.js
+++ b/test/controllers/recipe_controller_test.js
@@ -3,6 +3,7 @@ const recipeModel = require("../../src/models/recipes_model");
 const chai = require("chai"),
     chaiHttp = require("chai-http");
 const should = chai.should();
+const {expect} = chai;
 
 chai.use(chaiHttp);
 
@@ -27,10 +28,18 @@ describe("Endpoints exists for recipes", () => {
         });
     });
 
-    describe("/GET recipes by title", () => {
-        it("the get recipes/search should get recipes", (done) => {
+    describe("/POST search/filter recipes", () => {
+        it("the search recipe should get recipes", (done) => {
             chai.request(recipeRoutes).
-                get("/recipes/search?keyword=reci").
+                post("/recipes/search").
+                set("content-type", "application/json").
+                send({
+                    "query": {
+                        "$text": {
+                            "$search": "pork"
+                        }
+                    }
+                }).
                 end((err, res) => {
                     should.not.exist(err);
                     res.should.have.status(200);
@@ -47,6 +56,9 @@ describe("Endpoints exists for recipes", () => {
                 end((err, res) => {
                     should.not.exist(err);
                     res.should.have.status(200);
+                    expect(res.body).to.not.be.empty;
+                    expect(res.body.id).to.equal(25449);
+                    console.log(res.body)
                     done();
                 });
         });


### PR DESCRIPTION
We have decided to change the search endpoint to a post request + give the app developers the power to create the mongo queries they want!

Here is an example of the query:
POST: recipes/search
{
	"query": {
		"$text": {
			"$search": "pork"
		}, 
		"nutrition.calories.amount": {
			"$lt": 300
		}
	}
}