### PR TITLE
To set db_url environment variable in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     foodora:
         image: foodora/backend
         restart: on-failure
+        environment:
+            - DB_URL=mongodb://foodora-db:27017
         ports:
             - "8080:8080"
         depends_on:


### PR DESCRIPTION
Doing this because, in docker container, db is accessible at `foodoar-db` and not at `localhost`