### PR TITLE
Send null for non existing recipes when user is logged in

### DIFF
--- a/src/controllers/recipes_controller.js
+++ b/src/controllers/recipes_controller.js
@@ -57,7 +57,7 @@ module.exports.selectRecipeById = ({ params: { recipeId = null }, headers: { tok
     return res.status(400).json('Please enter the recipe Id');
   }
   return recipesModel.selectRecipeById(recipeId, (err, recipe) => {
-    if (token && !err) {
+    if (token && !err && recipe != null) {
       populateUserSpecificInfoOnRecipes(
         token,
         [recipe],

--- a/test/integration/controllers/recipe_controller_test.js
+++ b/test/integration/controllers/recipe_controller_test.js
@@ -146,6 +146,47 @@ describe('Endpoints exists for recipes', () => {
           done();
         });
     });
+
+    it('get recipe by Id should return null for non existing recipe', (done) => {
+      chai.request(routes)
+        .get('/recipes/id/0')
+        .end((err, res) => {
+          res.should.have.status(200);
+          should.not.exist(err);
+          should.not.exist(res.body);
+          done();
+        });
+    });
+
+    it('the get recipes by Id should return null for non existing recipe for logged in user', (done) => {
+      async.auto(
+        {
+          userRegister: autoCallback => chai.request(routes)
+            .post('/users')
+            .set('content-type', 'application/json')
+            .send({
+              email: 'user@email.com',
+              name: 'user',
+              password: '1234',
+            })
+            .end(autoCallback),
+          getRecipeWithToken: [
+            'userRegister',
+            ({ userRegister: { body: { token } } }, autoCallback) => chai.request(routes)
+              .get('/recipes/id/0')
+              .set('token', token)
+              .end(autoCallback),
+          ],
+        },
+        (err, { getRecipeWithToken }) => {
+          should.not.exist(err);
+          getRecipeWithToken.should.have.status(200);
+          should.not.exist(getRecipeWithToken.body);
+          done();
+        },
+      );
+    });
+
     it('the get recipes endpoint should return a list of all available recipes with user information when token is provided', (done) => {
       async.auto(
         {


### PR DESCRIPTION
Fixes: #85 

Calling `populateUserSpecificInfoOnRecipes` when recipes are null causes errors since the method exists recipes to exist. Fixing it by adding a check to see if recipes exist or not.